### PR TITLE
Convert backslashes to forwardslashes in file path

### DIFF
--- a/src/lib/generateSpecFile.js
+++ b/src/lib/generateSpecFile.js
@@ -16,7 +16,8 @@ function generateSpecFile(moduleName, specPath, unitPath, src, style = 'jest') {
   const spec = specUnit(moduleInfo);
 
   // why doesn't `relative` work without the slice?
-  const importPath = path.relative(specPath, unitPath).slice(3);
+  const importPath = path.relative(specPath, unitPath).slice(3)
+    .replace(/\\/g, '/'); // convert backslashes on windows
   const importLine = importDeclaration(moduleInfo, importPath);
 
   const fileContents = `/* @lazyspec (remove to manage manually) */


### PR DESCRIPTION
This avoids having backslashes in import paths in spec file when
running on windows

fixes #4 